### PR TITLE
Update instance types

### DIFF
--- a/docs/runners/index.md
+++ b/docs/runners/index.md
@@ -8,15 +8,15 @@ The CPU labeled runners are backed by various EC2 instances and do not have any 
 
 | Label               | EC2 Machine Type             |
 | ------------------- | ---------------------------- |
-| `linux-amd64-cpu4`  | `m5d.xlarge` ([specs][m5])   |
-| `linux-amd64-cpu8`  | `m5d.2xlarge` ([specs][m5])  |
-| `linux-amd64-cpu16` | `m5d.4xlarge` ([specs][m5])  |
-| `linux-arm64-cpu4`  | `m6gd.xlarge` ([specs][m6])  |
-| `linux-arm64-cpu8`  | `m6gd.2xlarge` ([specs][m6]) |
-| `linux-arm64-cpu16` | `m6gd.4xlarge` ([specs][m6]) |
+| `linux-amd64-cpu4`  | `m7i.xlarge` ([specs][m7i])   |
+| `linux-amd64-cpu8`  | `m7i.2xlarge` ([specs][m7i])  |
+| `linux-amd64-cpu16` | `m7i.4xlarge` ([specs][m7i])  |
+| `linux-arm64-cpu4`  | `m7g.xlarge` ([specs][m7g])  |
+| `linux-arm64-cpu8`  | `m7g.2xlarge` ([specs][m7g]) |
+| `linux-arm64-cpu16` | `m7g.4xlarge` ([specs][m7g]) |
 
-[m5]: https://aws.amazon.com/ec2/instance-types/m5/#Product_details
-[m6]: https://aws.amazon.com/ec2/instance-types/m6g/#Product_Details
+[m7i]: https://aws.amazon.com/ec2/instance-types/m7i/#Product_details
+[m7g]: https://aws.amazon.com/ec2/instance-types/m7g/#Product_Details
 
 <!-- prettier-ignore-start -->
 !!! info


### PR DESCRIPTION
This PR updates the instance types for our runners.

- `amd` nodes updated from [`m5`](https://aws.amazon.com/ec2/instance-types/m5/) to [`m7i`](https://aws.amazon.com/ec2/instance-types/m7i/)
- `arm` nodes updated from [`m6g`](https://aws.amazon.com/ec2/instance-types/m6g/) to [`m7g`](https://aws.amazon.com/ec2/instance-types/m7g/)