### PR TITLE
Update docs for enterprise runners

### DIFF
--- a/docs/apps/nvidia-runner-mgmt/index.md
+++ b/docs/apps/nvidia-runner-mgmt/index.md
@@ -1,0 +1,11 @@
+# Overview
+
+## Introduction
+
+The `nvidia-runner-mgmt` GitHub application provides NVIDIA with the necessary permissions to manage self-hosted runners in a particular GitHub organization. It is only intended to be installed by NVIDIA GitHub organizations. It supersedes the [`nvidia-runners`](../nvidia-runners/index.md) GitHub application.
+
+## Installation
+
+The application can be installed from this link: <https://github.com/apps/nvidia-runner-mgmt>.
+
+Additional details about how the application is used can be found in [nv-gha-runners/enterprise-runner-configuration](https://github.com/nv-gha-runners/enterprise-runner-configuration).

--- a/docs/onboarding/index.md
+++ b/docs/onboarding/index.md
@@ -2,10 +2,6 @@
 
 ## Introduction
 
-!!! note
-
-    This page does not apply to non-NVIDIA GitHub organizations. Non-NVIDIA GitHub organizations can can go [here](./non-nvidia.md) to proceed with onboarding instructions.
-
 This page outlines some important preliminary information that users will need to know about testing pull requests with NVIDIA's self-hosted runners.
 
 Once this information has been reviewed, follow the links at the bottom of this page to find out more about the onboarding process.
@@ -75,5 +71,3 @@ Once GitHub addresses the security concerns associated with using self-hosted ru
 ## Next Steps
 
 GitHub organizations that are a member of the NVIDIA GitHub Enterprise account can go [here](./nvidia.md) to proceed with onboarding instructions.
-
-GitHub Organizations that are not part of the NVIDIA GitHub Enterprise account can go [here](./non-nvidia.md).

--- a/docs/onboarding/non-nvidia.md
+++ b/docs/onboarding/non-nvidia.md
@@ -1,9 +1,0 @@
-# Overview
-
-The onboarding steps for non-NVIDIA GitHub organizations are:
-
-1. Review [this](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks) GitHub documentation and follow the links to enable required workflow approvals for pull requests from **all outside contributors**.
-   - This will help prevent abuse of our runners (e.g. crypto mining). **Organizations who do not enable this option may have their runner access revoked**. Setting this option at the organization level only affects new repositories. Therefore, the setting will need to be explicitly enabled for existing repositories as well.
-1. Review and install the [`nvidia-runners`](../apps/nvidia-runners/index.md) GitHub application
-   - Wait for confirmation from NVIDIA's GitHub Actions team before moving to the final step
-1. View the [runners](../runners/index.md) page and start using the self-hosted runners!

--- a/docs/onboarding/nvidia.md
+++ b/docs/onboarding/nvidia.md
@@ -1,14 +1,8 @@
 # Overview
 
-!!! note
-
-    The process for onboarding NVIDIA organizations will change in the future when we begin provisioning the runners to NVIDIA's GitHub Enterprise account.
-
-    This documentation will be updated accordingly when that happens.
-
 The onboarding steps for NVIDIA GitHub organizations are:
 
 1. Review and install the [`copy-pr-bot`](../apps/copy-pr-bot/index.md) GitHub application
-1. Review and install the [`nvidia-runners`](../apps/nvidia-runners/index.md) GitHub application
-   - Wait for confirmation from NVIDIA's GitHub Actions team before moving to the final step
+1. Review and install the [`nvidia-runner-mgmt`](../apps/nvidia-runner-mgmt/index.md) GitHub application
+1. Request access to runner groups in [nv-gha-runners/enterprise-runner-configuration](https://github.com/nv-gha-runners/enterprise-runner-configuration)
 1. View the [runners](../runners/index.md) page and start using the self-hosted runners!

--- a/docs/runners/index.md
+++ b/docs/runners/index.md
@@ -6,17 +6,7 @@ This page includes information about the self-hosted runners that are available 
 
 The CPU labeled runners are backed by various EC2 instances and do not have any GPUs installed.
 
-| Label               | EC2 Machine Type             |
-| ------------------- | ---------------------------- |
-| `linux-amd64-cpu4`  | `m7i.xlarge` ([specs][m7i])  |
-| `linux-amd64-cpu8`  | `m7i.2xlarge` ([specs][m7i]) |
-| `linux-amd64-cpu16` | `m7i.4xlarge` ([specs][m7i]) |
-| `linux-arm64-cpu4`  | `m7g.xlarge` ([specs][m7g])  |
-| `linux-arm64-cpu8`  | `m7g.2xlarge` ([specs][m7g]) |
-| `linux-arm64-cpu16` | `m7g.4xlarge` ([specs][m7g]) |
-
-[m7i]: https://aws.amazon.com/ec2/instance-types/m7i/#Product_details
-[m7g]: https://aws.amazon.com/ec2/instance-types/m7g/#Product_Details
+_Runner labels have been moved to [nv-gha-runners/enterprise-runner-configuration](https://github.com/nv-gha-runners/enterprise-runner-configuration). These resources will be consolidated in the future._
 
 <!-- prettier-ignore-start -->
 !!! info
@@ -45,16 +35,9 @@ The GPU labeled runners have the GPUs specified in the table below installed.
     2. They must set the `NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}` container environment variable
 
      If these requirements aren't met, the GitHub Actions job will fail. See the [_Example_](#example) section below for an example.
-
-     **These requirements do not apply to non-NVIDIA GitHub organizations.**
 <!-- prettier-ignore-end -->
 
-| Label                             | GPU    | Driver Version | # of GPUs |
-| --------------------------------- | ------ | -------------- | --------- |
-| `linux-amd64-gpu-v100-earliest-1` | `V100` | `470`          | `1`       |
-| `linux-amd64-gpu-v100-latest-1`   | `V100` | `535`          | `1`       |
-| `linux-arm64-gpu-a100-latest-1`   | `A100` | `535`          | `1`       |
-| `linux-amd64-gpu-t4-latest-1`     | `T4`   | `535`          | `1`       |
+_Runner labels have been moved to [nv-gha-runners/enterprise-runner-configuration](https://github.com/nv-gha-runners/enterprise-runner-configuration). These resources will be consolidated in the future._
 
 <!-- prettier-ignore-start -->
 !!! info

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,7 +56,6 @@ nav:
       - Onboarding:
           - onboarding/index.md
           - NVIDIA Orgs: onboarding/nvidia.md
-          - Non-NVIDIA Orgs: onboarding/non-nvidia.md
   - GitHub Applications:
       - apps/index.md
       - Copy PR Bot:
@@ -64,5 +63,7 @@ nav:
           - FAQs: apps/copy-pr-bot/faqs.md
       - NVIDIA Runners:
           - apps/nvidia-runners/index.md
+      - NVIDIA Runner Mgmt:
+          - apps/nvidia-runner-mgmt/index.md
   - Runners:
       - runners/index.md


### PR DESCRIPTION
This PR updates our documentation to include information about Enterprise runner support.

Specifically, it includes the following changes:

- Updates the NVIDIA onboarding section to reference the new [nvidia-runner-mgmt](https://github.com/apps/nvidia-runner-mgmt) app
- Adds a section explicitly about the [nvidia-runner-mgmt](https://github.com/apps/nvidia-runner-mgmt) app
- Removes our runner labels since they are being migrated to the [nv-gha-runners/enterprise-runner-configuration](https://github.com/nv-gha-runners/enterprise-runner-configuration) repository
- Removes onboarding information for non-NVIDIA orgs since we are still a long way from being able to support them

As a future initiative, I will overhaul this site to make it SSO-protected and re-add the runner labels so that all of our self-hosted runner information is consolidated in a single place.